### PR TITLE
Add OMP agent config

### DIFF
--- a/dotfiles/.omp/agent/config.yml
+++ b/dotfiles/.omp/agent/config.yml
@@ -1,0 +1,9 @@
+lastChangelogVersion: 15.1.7
+modelRoles: 
+  default: openai-codex/gpt-5.5:high
+tools: 
+  discoveryMode: mcp-only
+memories: 
+  enabled: true
+memory: 
+  backend: local

--- a/sync-cli-dotfiles.sh
+++ b/sync-cli-dotfiles.sh
@@ -24,6 +24,9 @@ cp -v "$SRC/.config/mise/config.toml" "$DST/.config/mise/config.toml"
 
 cp -v "$SRC/.config/starship.toml" "$DST/.config/starship.toml"
 
+mkdir -p "$DST/.omp/agent"
+cp -v "$SRC/.omp/agent/config.yml" "$DST/.omp/agent/config.yml"
+
 # Neovim config
 mkdir -p "$DST/.config/nvim"
 cp -rv "$SRC/.config/nvim/." "$DST/.config/nvim/"


### PR DESCRIPTION
## Summary
- add the OMP agent YAML config under `dotfiles/.omp/agent/config.yml`
- set `modelRoles.default` to `openai-codex/gpt-5.5:high`
- update `sync-cli-dotfiles.sh` so the YAML config is copied with the other CLI dotfiles
- the committed YAML contains only local OMP settings and no secret material

## Verification
- `bash -n sync-cli-dotfiles.sh`
- verified `dotfiles/.omp/agent/config.yml` contains `default: openai-codex/gpt-5.5:high`
- ran `./sync-cli-dotfiles.sh` against a fresh temp directory and verified `.omp/agent/config.yml` was copied and `.omp/agent/config.toml` was not created
- verified the branch diff no longer contains `config.toml`