### PR TITLE
Make pi default agent-deck tool

### DIFF
--- a/dotfiles/.agent-deck/config.toml
+++ b/dotfiles/.agent-deck/config.toml
@@ -1,7 +1,7 @@
 # Agent Deck Configuration
 # Edit this file or use Settings (press S) in the TUI
 
-default_tool = "omp"
+default_tool = "pi"
 theme = "system"
 mcp_default_scope = ""
 


### PR DESCRIPTION
## Summary\n- Set Agent Deck's default tool to pi in the dotfiles config\n\n## Testing\n- Not run (configuration-only change)